### PR TITLE
Update version handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 env:
   - TOOL_NAME=promtool TOOL_VERSION=v2.11.1 TOOL_TEST_COMMAND='promtool --version'
 before_script:
+  - sudo apt-get -y install jq
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 script:

--- a/bin/install
+++ b/bin/install
@@ -59,10 +59,8 @@ get_filename() {
   local version="$1"
   local platform="$2"
   local binary_name="$3"
-  local version_short
-  version_short="$(echo "$version" | tr -d 'v')"
 
-  echo "prometheus-${version_short}.${platform}.tar.gz"
+  echo "prometheus-${version}.${platform}.tar.gz"
 }
 
 # https://github.com/prometheus/prometheus/releases/download/v2.11.1/prometheus-2.11.1.linux-amd64.tar.gz
@@ -74,7 +72,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/prometheus/prometheus/releases/download/${version}/${filename}"
+  echo "https://github.com/prometheus/prometheus/releases/download/v${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,20 +1,16 @@
 #!/usr/bin/env bash
 
-github_coordinates=prometheus/prometheus
-releases_path="https://api.github.com/repos/${github_coordinates}/releases"
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+set -euo pipefail
+
+github_path='prometheus/prometheus'
+releases_path="https://api.github.com/repos/${github_path}/releases"
+cmd='curl -f -s'
+if [[ -n "${GITHUB_API_TOKEN-}" ]]; then
+  cmd="${cmd} -H 'Authorization: token ${GITHUB_API_TOKEN}'"
 fi
-cmd="$cmd $releases_path"
+cmd="${cmd} ${releases_path}"
 
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' \
-    | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
-# shellcheck disable=SC2086
-echo $versions
+eval "${cmd}" |
+  jq '.[] | select(.prerelease == false) | .tag_name | sub("v"; "")' -r |
+  sort --version-sort |
+  xargs echo


### PR DESCRIPTION
* Use jq to parse the releases json.
* Skip pre-releases.
* Simplify version sort.
* Strip the `v` from the version list for asdf style.

Signed-off-by: Ben Kochie <superq@gmail.com>