### PR TITLE
Added support for latest

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -8,4 +8,5 @@ IFS=$'\t\n' # Stricter IFS settings
 plugin_dir=$(dirname "$0")
 # shellcheck disable=SC2086
 versions=$(${plugin_dir}/list-all)
+# shellcheck disable=SC2086
 echo ${versions##* }

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# List all versions using the command and keep the latest
+set -euo pipefail
+#ORIGINAL_IFS=$IFS
+IFS=$'\t\n' # Stricter IFS settings
+
+plugin_dir=$(dirname "$0")
+# shellcheck disable=SC2086
+versions=$(${plugin_dir}/list-all)
+echo ${versions##* }


### PR DESCRIPTION
Because the promtool package uses the vXXX prefix the command `asdf promtool latest` does not return anything. 

Instead of removing the v as #2 is doing, this adds support to getting the latest version using a asdf feature introduced in v0.9.0 https://github.com/asdf-vm/asdf/releases/tag/v0.9.0